### PR TITLE
rename get_webui_url to get_dashboard_url

### DIFF
--- a/ray-crash-course/01-Ray-Tasks.ipynb
+++ b/ray-crash-course/01-Ray-Tasks.ipynb
@@ -197,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Dashboard URL: http://{ray.get_webui_url()}')"
+    "print(f'Dashboard URL: http://{ray.get_dashboard_url()}')"
    ]
   },
   {

--- a/ray-crash-course/02-Ray-Actors.ipynb
+++ b/ray-crash-course/02-Ray-Actors.ipynb
@@ -481,7 +481,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'New port? http://{ray.get_webui_url()}')"
+    "print(f'New port? http://{ray.get_dashboard_url()}')"
    ]
   },
   {

--- a/ray-crash-course/04-Ray-Multiprocessing.ipynb
+++ b/ray-crash-course/04-Ray-Multiprocessing.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Dashboard URL: http://{ray.get_webui_url()}')"
+    "print(f'Dashboard URL: http://{ray.get_dashboard_url()}')"
    ]
   },
   {

--- a/ray-crash-course/05-Ray-Parallel-Iterators.ipynb
+++ b/ray-crash-course/05-Ray-Parallel-Iterators.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Dashboard URL: http://{ray.get_webui_url()}')"
+    "print(f'Dashboard URL: http://{ray.get_dashboard_url()}')"
    ]
   },
   {


### PR DESCRIPTION
I am getting `AttributeError: module 'ray' has no attribute 'get_webui_url'` error with more recent versions of **ray** because the `webui` was simply renamed to `dashboard` for 1.0 with [this commit](https://github.com/ray-project/ray/commit/519354a39afb3fb3fb5cfa69ecab3c6364843fb8).